### PR TITLE
Fix travis deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: ruby
 
 rvm:
-  - 2.3.3
   - 2.4.0
 
 before_install:
@@ -13,7 +12,6 @@ before_install:
 cache: bundler
 script: bundle exec middleman build
 deploy:
-  local_dir: build
   provider: pages
   cleanup: true
   token: $GITHUB_TOKEN


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fix travis deployment

## Context
<!--- Why is this change required? What problem does it solve? -->
Fix travis deployment to GH pages.
Previously it returned an error:
`Could not copy /home/travis/build/Skyscanner/travel-insight-api/build.`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Unit/Integration Tests have added/modified for this change.
- [ ] Tested the changes locally.
- [ ] Updated Confluence pages if applicable.

### Screenshots (if its a UI change)
<!--- Add screenshots for easier PR review -->

### Link to Jira(if available)
JIRA - 

### Link to Confluence(if available)
Confluence - 
