### PR TITLE
Revert "Bump rack from 2.0.7 to 2.2.2"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
       activesupport (>= 3.1)
     parallel (1.17.0)
     public_suffix (3.1.0)
-    rack (2.2.2)
+    rack (2.0.7)
     rake (12.3.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)


### PR DESCRIPTION
Reverts Skyscanner/travel-insight-api#1