### PR TITLE
ROBINS-1599: Replace "Data is available for rolling 365" with "Data i…

### DIFF
--- a/source/includes/_scope.md
+++ b/source/includes/_scope.md
@@ -78,6 +78,6 @@
 -	Max date interval supported in a query: 30 days, by default
 -	Max number of queries allowed in a minute: 1
 -	Partner's API key must be available in `API-Key` request header
-- Data is available for rolling 365 days in the past, by default.
+- Data is available from 2018-01-01, by default.
 -	Maximum number of results returned in an API call is 100000 and the API does not support paging at this stage.
 -	Be aware that **searches** can be done on a city or airport level. Consider this when using the **originIATA** or **destinationIATA** filters. eg all searches for London should use the followings values: LHR, LCY, LGW, LTN, SEN (airport codes) **and** LON (IATA code for the city)


### PR DESCRIPTION
…s available from 2018-01-01".

## Description

Replace "Data is available for rolling 365" with "Data is available from 2018-01-01".

## Context

Related to replacing maxDaysFromToday with startDate in subscriptions

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Unit/Integration Tests have added/modified for this change.
- [ ] Tested the changes locally.
- [ ] Updated Confluence pages if applicable.

### Screenshots (if its a UI change)
<!--- Add screenshots for easier PR review -->

### Link to Jira(if available)
https://gojira.skyscanner.net/browse/ROBINS-1651

### Link to Confluence(if available)
Confluence - 
