### PR TITLE
ROBINS-1980 Add included into exits and searches

### DIFF
--- a/source/includes/_exits.md
+++ b/source/includes/_exits.md
@@ -38,13 +38,15 @@
       ]
     }
   ],
-  "included": [
-    {
-      "market": "ES",
-      "origin": "BCN",
-      "destination": "*"
-    }
-  ]
+  "subscription": {
+    "included": [
+      {
+        "market": "ES",
+        "origin": "BCN",
+        "destination": "*"
+      }
+    ]
+  }
 }
 ```
 

--- a/source/includes/_exits.md
+++ b/source/includes/_exits.md
@@ -37,6 +37,13 @@
         },
       ]
     }
+  ],
+  "included": [
+    {
+      "market": "ES",
+      "origin": "BCN",
+      "destination": "*"
+    }
   ]
 }
 ```

--- a/source/includes/_scope.md
+++ b/source/includes/_scope.md
@@ -26,7 +26,7 @@
 - **userRegionCode:** Region name of the user
 - **userRegionName:** Region code of the user
 - **distanceToOriginInMetres:** Distance in meters between the user location and the departing airport
-- **included**: Markets and routes included into the partner subscription. "*" means "anything".
+- **subscription.included**: Markets and routes included into the partner subscription. "*" means "anything".
 
 
 ### On exits(**redirects**) data:
@@ -61,7 +61,7 @@
 - **userRegionCode:** Region name of the user
 - **userRegionName:** Region code of the user
 - **distanceToOriginInMetres:** Distance in meters between the user location and the departing airport
-- **included**: Markets and routes included into the partner subscription. "*" means "anything".
+- **subscription.included**: Markets and routes included into the partner subscription. "*" means "anything".
 
 
 ## Supported Aggregations

--- a/source/includes/_scope.md
+++ b/source/includes/_scope.md
@@ -26,7 +26,7 @@
 - **userRegionCode:** Region name of the user
 - **userRegionName:** Region code of the user
 - **distanceToOriginInMetres:** Distance in meters between the user location and the departing airport
-- **subscription.included**: Markets and routes included into the partner subscription. "*" means "anything".
+- **subscription.included**: Markets and routes included into your subscription. "*" means "anything".
 
 
 ### On exits(**redirects**) data:
@@ -61,7 +61,7 @@
 - **userRegionCode:** Region name of the user
 - **userRegionName:** Region code of the user
 - **distanceToOriginInMetres:** Distance in meters between the user location and the departing airport
-- **subscription.included**: Markets and routes included into the partner subscription. "*" means "anything".
+- **subscription.included**: Markets and routes included into your subscription. "*" means "anything".
 
 
 ## Supported Aggregations

--- a/source/includes/_scope.md
+++ b/source/includes/_scope.md
@@ -26,7 +26,7 @@
 - **userRegionCode:** Region name of the user
 - **userRegionName:** Region code of the user
 - **distanceToOriginInMetres:** Distance in meters between the user location and the departing airport
-- **subscription.included**: Markets and routes included into your subscription. "*" means "anything".
+- **subscription.included**: Markets and routes included in your subscription. "*" means "anything".
 
 
 ### On exits(**redirects**) data:
@@ -61,7 +61,7 @@
 - **userRegionCode:** Region name of the user
 - **userRegionName:** Region code of the user
 - **distanceToOriginInMetres:** Distance in meters between the user location and the departing airport
-- **subscription.included**: Markets and routes included into your subscription. "*" means "anything".
+- **subscription.included**: Markets and routes included in your subscription. "*" means "anything".
 
 
 ## Supported Aggregations

--- a/source/includes/_scope.md
+++ b/source/includes/_scope.md
@@ -26,6 +26,7 @@
 - **userRegionCode:** Region name of the user
 - **userRegionName:** Region code of the user
 - **distanceToOriginInMetres:** Distance in meters between the user location and the departing airport
+- **included**: Markets and routes included into the partner subscription. "*" means "anything".
 
 
 ### On exits(**redirects**) data:
@@ -60,6 +61,7 @@
 - **userRegionCode:** Region name of the user
 - **userRegionName:** Region code of the user
 - **distanceToOriginInMetres:** Distance in meters between the user location and the departing airport
+- **included**: Markets and routes included into the partner subscription. "*" means "anything".
 
 
 ## Supported Aggregations

--- a/source/includes/_searches.md
+++ b/source/includes/_searches.md
@@ -26,7 +26,14 @@
           "value": "SG"
         }
       ],
-      "aggregations": "count"
+      "aggregations": "count",
+      "included": [
+        {
+          "market": "ES",
+          "origin": "BCN",
+          "destination": "*"
+        }
+      ]
     }
   ]
 }

--- a/source/includes/_searches.md
+++ b/source/includes/_searches.md
@@ -27,13 +27,15 @@
         }
       ],
       "aggregations": "count",
-      "included": [
-        {
-          "market": "ES",
-          "origin": "BCN",
-          "destination": "*"
-        }
-      ]
+      "subscription": {
+        "included": [
+          {
+            "market": "ES",
+            "origin": "BCN",
+            "destination": "*"
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
## Description
Adding markets and routes included into a subscription.
Needed to remind the partner that he/she can have limitations.
So there would be no surprise when we will start filtering the response data later on.

## Context
Currently even if a partner is allowed to query only a single market, Iris API will allow to query everything.
It's a way for a partner to save a bit of money. But not so good for Skyscanner.



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Unit/Integration Tests have added/modified for this change.
- [ ] Tested the changes locally.
- [ ] Updated Confluence pages if applicable.

### Screenshots (if its a UI change)
<!--- Add screenshots for easier PR review -->

### Link to Jira(if available)
JIRA - https://gojira.skyscanner.net/browse/ROBINS-1980

### Link to Confluence(if available)
Confluence - 
