### PR TITLE
[ ROBINS-2800 ]userRegionCode removed from iris documentation update

### DIFF
--- a/source/includes/_scope.md
+++ b/source/includes/_scope.md
@@ -84,4 +84,3 @@ Results are sorted by the count value (descending)
 - Data is available from 2018-01-01, by default.
 -	Maximum number of results returned in an API call is 100000 and the API does not support paging at this stage.
 -	Be aware that **searches** can be done on a city or airport level. Consider this when using the **originIATA** or **destinationIATA** filters. eg all searches for London should use the followings values: LHR, LCY, LGW, LTN, SEN (airport codes) **and** LON (IATA code for the city)
-- Have in mind, **userRegionCode** has been removed from iris since it is always null, but still kept in interface in both searches and redirects to avoid breaking customer queries. 

--- a/source/includes/_scope.md
+++ b/source/includes/_scope.md
@@ -23,8 +23,7 @@
 - **userCityLongitude:** Longitude of the user location
 - **userCityName:** City name of the user
 - **userCountryCode:** Country code of the user
-- **userRegionCode:** Region name of the user
-- **userRegionName:** Region code of the user
+- **userRegionName:** Region name of the user
 - **distanceToOriginInMetres:** Distance in meters between the user location and the departing airport
 - **subscription.included**: Markets and routes included in your subscription. "*" means "anything".
 
@@ -58,8 +57,7 @@
 - **userCityLongitude:** Longitude of the user location
 - **userCityName:** City name of the user
 - **userCountryCode:** Country code of the user
-- **userRegionCode:** Region name of the user
-- **userRegionName:** Region code of the user
+- **userRegionName:** Region name of the user
 - **distanceToOriginInMetres:** Distance in meters between the user location and the departing airport
 - **subscription.included**: Markets and routes included in your subscription. "*" means "anything".
 
@@ -86,3 +84,4 @@ Results are sorted by the count value (descending)
 - Data is available from 2018-01-01, by default.
 -	Maximum number of results returned in an API call is 100000 and the API does not support paging at this stage.
 -	Be aware that **searches** can be done on a city or airport level. Consider this when using the **originIATA** or **destinationIATA** filters. eg all searches for London should use the followings values: LHR, LCY, LGW, LTN, SEN (airport codes) **and** LON (IATA code for the city)
+- Have in mind, **userRegionCode** has been removed from iris since it is always null, but still kept in interface in both searches and redirects to avoid breaking customer queries. 


### PR DESCRIPTION
## Description
userRegionCode removal from iris documentation update
## Context
The travel insights API Iris update for userRegionCode, which is a field that is ingested into druid from converter data. This field is always null and has been there for backwards compatibility. 

## Checklist:
userRegionCode removed from searches and redirects in _scope
userRegionName edited with the correct description


### Link to Jira(if available)
JIRA - https://gojira.skyscanner.net/browse/ROBINS-2800

